### PR TITLE
Add a Twitter bot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,19 +23,12 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
-# Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-gem 'spring',        group: :development
+group :development do
+  gem 'spring'
+  gem 'pry'
+end
 
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use unicorn as the app server
-# gem 'unicorn'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
-# Use debugger
-# gem 'debugger', group: [:development, :test]
+gem 'twitter'
+gem 'httparty'
 
 gem 'rails_12factor', group: :production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,11 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (5.0.1.20140414130214)
+    buftok (0.2.0)
     builder (3.2.2)
+    coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -36,9 +39,18 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.8.0)
+    equalizer (0.0.11)
     erubis (2.7.0)
     execjs (2.2.2)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     hike (1.2.3)
+    http (0.6.3)
+      http_parser.rb (~> 0.6.0)
+    http_parser.rb (0.6.0)
+    httparty (0.13.5)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     i18n (0.6.11)
     jbuilder (2.2.3)
       activesupport (>= 3.0.0, < 5)
@@ -49,10 +61,20 @@ GEM
     json (1.8.1)
     mail (2.6.1)
       mime-types (>= 1.16, < 3)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    method_source (0.8.2)
     mime-types (2.4.2)
     minitest (5.4.2)
     multi_json (1.10.1)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
+    naught (1.0.0)
     pg (0.17.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -88,6 +110,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    simple_oauth (0.3.1)
+    slop (3.6.0)
     spring (1.1.3)
     sprockets (2.11.0)
       hike (~> 1.2)
@@ -103,6 +127,17 @@ GEM
     tilt (1.4.1)
     turbolinks (2.4.0)
       coffee-rails
+    twitter (5.14.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (~> 0.0.9)
+      faraday (~> 0.9.0)
+      http (~> 0.6.0)
+      http_parser.rb (~> 0.6.0)
+      json (~> 1.8)
+      memoizable (~> 0.4.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.5.3)
@@ -114,13 +149,16 @@ PLATFORMS
 
 DEPENDENCIES
   coffee-rails (~> 4.0.0)
+  httparty
   jbuilder (~> 2.0)
   jquery-rails
   pg
+  pry
   rails (= 4.1.6)
   rails_12factor
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   spring
   turbolinks
+  twitter
   uglifier (>= 1.3.0)

--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,6 +1,4 @@
 class RobotsController < ApplicationController
-  before_action :fetch_startup, only: [:find_similar]
-
   def index
     render json: {
       status: "This is just a bot"

--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,4 +1,9 @@
 class RobotsController < ApplicationController
+  before_action :fetch_startup, only: [:find_similar]
+
   def index
+    render json: {
+      status: "This is just a bot"
+    }
   end
 end

--- a/app/models/startup_tag.rb
+++ b/app/models/startup_tag.rb
@@ -1,0 +1,2 @@
+class StartupTag < ActiveRecord::Base
+end

--- a/app/models/timeline.rb
+++ b/app/models/timeline.rb
@@ -1,0 +1,2 @@
+class Timeline < ActiveRecord::Base
+end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,0 +1,2 @@
+ANGEL_URL = "https://api.angel.co/1"
+ANGEL_TOKEN = ENV["ANGELLIST_OAUTH_TOKEN"]

--- a/config/initializers/twitter.rb
+++ b/config/initializers/twitter.rb
@@ -1,0 +1,6 @@
+TwitterClient = Twitter::REST::Client.new do |config|
+  config.consumer_key        = ENV["TWITTER_API_KEY"]
+  config.consumer_secret     = ENV["TWITTER_API_SECRET"]
+  config.access_token        = ENV["TWITTER_ACCESS_TOKEN"]
+  config.access_token_secret = ENV["TWITTER_ACCESS_SECRET"]
+end

--- a/db/migrate/20150705034548_create_timelines.rb
+++ b/db/migrate/20150705034548_create_timelines.rb
@@ -1,0 +1,13 @@
+class CreateTimelines < ActiveRecord::Migration
+  def change
+    create_table :timelines do |t|
+      t.string :tweet_id
+      t.string :tweet
+      t.string :tweet_by
+      t.string :mentioned_startup
+      t.boolean :replied, default: false
+      t.boolean :replied_startup
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150705085641_create_startup_tags.rb
+++ b/db/migrate/20150705085641_create_startup_tags.rb
@@ -1,0 +1,12 @@
+class CreateStartupTags < ActiveRecord::Migration
+  def change
+    create_table :startup_tags do |t|
+      t.integer :angel_id, null: false
+      t.string :name
+      t.integer :children
+      t.integer :result_pages, default: 1
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,39 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20150705085641) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "startup_tags", force: true do |t|
+    t.integer  "angel_id",                 null: false
+    t.string   "name"
+    t.integer  "children"
+    t.integer  "result_pages", default: 1
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "timelines", force: true do |t|
+    t.string   "tweet_id"
+    t.string   "tweet"
+    t.string   "tweet_by"
+    t.string   "mentioned_startup"
+    t.boolean  "replied",           default: false
+    t.boolean  "replied_startup"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,5 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+Timeline.create(:tweet_id => 1)

--- a/lib/angel.rb
+++ b/lib/angel.rb
@@ -1,0 +1,98 @@
+module Angel
+
+  def get_similar startup_name
+    @startup = find_startup startup_name
+    unless @startup.present?
+      puts "Couldn't find the startup from search."
+      return false
+    end
+    puts "Found the startup from search. Getting more info. ID - #{@startup["id"]}"
+
+    fetch_info @startup["id"].to_s
+    if @startup["hidden"]
+      puts "Startup have it's details hidden. Couldn't proceed."
+      return false
+    end
+
+    if @startup["markets"].present?
+      puts "Got more Info about the Startup. Fetching Market Tags and their children count. ID - #{@startup["id"]}"
+      tags_hash = fetch_tag_children @startup["markets"]
+    elsif @startup["locations"].present?
+      puts "The startup has no Market tags. Fetching from Location tags. ID - #{@startup["id"]}"
+      tags_hash = fetch_tag_children @startup["locations"]
+    else
+      puts "The startup has no Location Tags or Market tags. Couldn't proceed. ID - #{@startup["id"]}"
+      return false
+    end
+
+    puts "Got Tag Information. Getting startups from the tag. ID - #{@startup["id"]}"
+    @similar = {}
+    tags_hash.each do |k, v|
+      @similar = find_startup_by_tag k
+      if @similar.present?
+        puts "Found a similar startup!"
+        break
+      end
+    end
+    return @similar
+  end
+
+  def find_startup startup_name
+    params_hash = {
+          query: startup_name,
+          type: "Startup",
+          access_token: ANGEL_TOKEN
+        }
+    search_url = ANGEL_URL + '/search?' + params_hash.to_param
+    results = HTTParty.get(search_url).as_json
+
+    return results.first
+  end
+
+  def fetch_info id
+    fetch_url = ANGEL_URL + '/startups/' + id + '?access_token=' + ANGEL_TOKEN
+    @startup = HTTParty.get(fetch_url).as_json
+  end
+
+  def fetch_tag_children tags
+    children = {}
+    tags.each do |tag|
+      unless saved_tag = StartupTag.find_by_angel_id(tag["id"])
+        tag_url = ANGEL_URL + '/tags/' + tag["id"].to_s + '?access_token=' + ANGEL_TOKEN
+        result = HTTParty.get(tag_url).as_json
+        saved_tag = StartupTag.create(:angel_id => tag["id"], :name => tag["name"], :children => result["total"])
+      end
+
+      children[saved_tag.angel_id] = saved_tag.children
+    end
+    Hash[children.sort]
+  end
+
+  def find_startup_by_tag tag_id
+    @tag = StartupTag.find_by_angel_id tag_id
+    params = {
+      access_token: ANGEL_TOKEN,
+      page: rand(1..@tag.result_pages)
+    }
+    fetch_url = ANGEL_URL + '/tags/' + @tag.angel_id.to_s + '/startups?' + params.to_param
+    results = HTTParty.get(fetch_url).as_json
+    unless results.present?
+      return false
+    end
+
+    @tag.update_attributes(:result_pages => results["last_page"])
+
+    results["startups"].each do |startup|
+      if startup["hidden"]
+        next
+      else
+        return {
+                :name => startup["name"],
+                :summary =>startup["high_concept"]
+                }
+        break
+      end
+    end
+  end
+
+end

--- a/lib/tasks/twitter.rake
+++ b/lib/tasks/twitter.rake
@@ -6,6 +6,11 @@ namespace :twitter do
     bot_name = ENV["BOT_NAME"]
     last_tweet = Timeline.last.tweet_id.to_i
     TwitterClient.mentions_timeline({:since_id => last_tweet}).each do |tweet|
+      #avoid duplicate tweets by exiting if already processed tweets come back
+      if Timeline.find_by_tweet_id tweet.id
+        break
+      end
+
       startup = tweet.text.gsub(bot_name, "").strip
       author = tweet.user.screen_name
       puts "Got a new tweet to process from @#{author} on startup - #{startup}. Off to work."

--- a/lib/tasks/twitter.rake
+++ b/lib/tasks/twitter.rake
@@ -1,0 +1,35 @@
+require 'angel'
+include Angel
+
+namespace :twitter do
+  task process: [:environment] do
+    bot_name = ENV["BOT_NAME"]
+    last_tweet = Timeline.last.tweet_id.to_i
+    TwitterClient.mentions_timeline({:since_id => last_tweet}).each do |tweet|
+      startup = tweet.text.gsub(bot_name, "").strip
+      author = tweet.user.screen_name
+      puts "Got a new tweet to process from @#{author} on startup - #{startup}. Off to work."
+      timeline = Timeline.new(:tweet_id => tweet.id, :tweet => tweet.text, :tweet_by => author,
+        :mentioned_startup => startup)
+
+      result = Angel.get_similar startup
+
+      puts "Replying to User."
+      unless result
+        puts "Couldn't find the startup or there were some obstacles."
+        timeline.replied_startup = "NA"
+        post_tweet(author, "Couldn't find the startup name, either u've misspelled or i'm drunk..")
+      else
+        timeline.replied = true
+        timeline.replied_startup = result[:name]
+        post_tweet(author, "Similar: #{result[:name]} - #{result[:summary]}")
+      end
+      timeline.save!
+    end
+    puts "All Done! Going to sleep."
+  end
+end
+
+def post_tweet author, message
+  TwitterClient.update("@#{author}: #{message}")
+end

--- a/test/fixtures/startup_tags.yml
+++ b/test/fixtures/startup_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  angel_id: 1
+  name: MyString
+  children: 1
+
+two:
+  angel_id: 1
+  name: MyString
+  children: 1

--- a/test/fixtures/timelines.yml
+++ b/test/fixtures/timelines.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined.  If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+#  column: value

--- a/test/models/startup_tag_test.rb
+++ b/test/models/startup_tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class StartupTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/timeline_test.rb
+++ b/test/models/timeline_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TimelineTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Twitter bot - https://twitter.com/similar_startup

When tweeted @ this bot with a startup name, it replies with a similar startup. (Note: Similar, not competitors).

### To Setup:
To get up and running this app locally, following details are required:

* Twitter Consumer Key
* Twitter Consumer Secret
* Twitter Auth Token
* Twitter Auth Secret
* AngelList Auth Token

Need to run rake db:seed before starting up.

#### Flow:
* Gets the startup name when tweeted at.
* Searches for the startup name and if available gets more information of it.
* Gets the market the startup is tagged into, and gets each tags and their child tags count. This is to fix on tags at the bottom of the chain to increase relevancy.
* Gets startups tagged to that market, randomly picks one and replies.

#### Things that can be improved:
To increase the relevancy, this can be extended by making text similarity matching between two startup summaries, investors, location targeted, comments, follower count.

#### Caveats:
The Twitter endpoint to fetch mention timeline tweets > given id fails sometimes, causing duplicate tweets. So, added a check at the beginning of processing pipeline to eliminate duplicate tweets when they come.